### PR TITLE
Handle redirect back from external browser or app

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -23,6 +23,20 @@
 
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
+
+            <!-- The intent filter for Components can be configured with any values as long as the `returnUrl` sent to the backend matches it. -->
+            <!-- In this case the `returnUrl` should be `adyencheckout://your.application.id/googlepay`. -->
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data
+                    android:host="${applicationId}"
+                    android:path="/googlepay"
+                    android:scheme="adyencheckout" />
+            </intent-filter>
         </activity>
 
     </application>

--- a/app/src/main/java/com/example/adyen/checkout/googlepay/ui/checkout/CheckoutActivity.kt
+++ b/app/src/main/java/com/example/adyen/checkout/googlepay/ui/checkout/CheckoutActivity.kt
@@ -1,9 +1,11 @@
 package com.example.adyen.checkout.googlepay.ui.checkout
 
+import android.content.Intent
 import android.os.Bundle
 import androidx.activity.compose.setContent
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
+import com.adyen.checkout.redirect.RedirectComponent
 
 class CheckoutActivity : AppCompatActivity() {
 
@@ -15,6 +17,15 @@ class CheckoutActivity : AppCompatActivity() {
             CheckoutScreen(
                 viewModel = checkoutViewModel,
             )
+        }
+    }
+
+    override fun onNewIntent(intent: Intent) {
+        super.onNewIntent(intent)
+
+        val data = intent.data
+        if (data != null && data.toString().startsWith(RedirectComponent.REDIRECT_RESULT_SCHEME)) {
+            checkoutViewModel.handleIntent(intent)
         }
     }
 }

--- a/app/src/main/java/com/example/adyen/checkout/googlepay/ui/checkout/CheckoutScreen.kt
+++ b/app/src/main/java/com/example/adyen/checkout/googlepay/ui/checkout/CheckoutScreen.kt
@@ -1,5 +1,6 @@
 package com.example.adyen.checkout.googlepay.ui.checkout
 
+import android.content.Intent
 import androidx.activity.compose.LocalActivity
 import androidx.annotation.StringRes
 import androidx.compose.foundation.layout.Box
@@ -43,6 +44,14 @@ fun CheckoutScreen(
                 onFinished = viewModel::actionHandled
             )
         }
+
+        state.handleIntent?.let {
+            HandleIntent(
+                intent = it.intent,
+                googlePayComponentData = it.googlePayComponentData,
+                onFinished = viewModel::intentHandled
+            )
+        }
     }
 }
 
@@ -75,6 +84,17 @@ private fun HandleAction(
     val googlePayComponent = getGooglePayComponent(googlePayComponentData)
     val activity = LocalActivity.current ?: return
     googlePayComponent.handleAction(action, activity)
+    onFinished()
+}
+
+@Composable
+private fun HandleIntent(
+    intent: Intent,
+    googlePayComponentData: GooglePayComponentData,
+    onFinished: () -> Unit,
+) {
+    val googlePayComponent = getGooglePayComponent(googlePayComponentData)
+    googlePayComponent.handleIntent(intent)
     onFinished()
 }
 

--- a/app/src/main/java/com/example/adyen/checkout/googlepay/ui/checkout/CheckoutState.kt
+++ b/app/src/main/java/com/example/adyen/checkout/googlepay/ui/checkout/CheckoutState.kt
@@ -1,11 +1,13 @@
 package com.example.adyen.checkout.googlepay.ui.checkout
 
+import android.content.Intent
 import androidx.annotation.StringRes
 import com.adyen.checkout.components.core.action.Action
 
 data class CheckoutState(
     val checkoutUIState: CheckoutUIState = CheckoutUIState.LoadingSpinner,
     val handleAction: HandleAction? = null,
+    val handleIntent: HandleIntent? = null,
 )
 
 sealed class CheckoutUIState {
@@ -17,3 +19,5 @@ sealed class CheckoutUIState {
 }
 
 data class HandleAction(val action: Action, val googlePayComponentData: GooglePayComponentData)
+
+data class HandleIntent(val intent: Intent, val googlePayComponentData: GooglePayComponentData)

--- a/app/src/main/java/com/example/adyen/checkout/googlepay/ui/checkout/CheckoutViewModel.kt
+++ b/app/src/main/java/com/example/adyen/checkout/googlepay/ui/checkout/CheckoutViewModel.kt
@@ -1,6 +1,7 @@
 package com.example.adyen.checkout.googlepay.ui.checkout
 
 import android.app.Application
+import android.content.Intent
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
 import com.adyen.checkout.components.core.CheckoutConfiguration
@@ -139,6 +140,19 @@ class CheckoutViewModel(
     fun actionHandled() {
         _checkoutState.update { currentState ->
             currentState.copy(handleAction = null)
+        }
+    }
+
+    fun handleIntent(intent: Intent) {
+        val googlePayComponentData = googlePayComponentData ?: return
+        _checkoutState.update { currentState ->
+            currentState.copy(handleIntent = HandleIntent(intent, googlePayComponentData))
+        }
+    }
+
+    fun intentHandled() {
+        _checkoutState.update { currentState ->
+            currentState.copy(handleIntent = null)
         }
     }
 


### PR DESCRIPTION
## Context

Scenarios such as a 3DS challenge in a web browser require handling the redirect back to the SDK through the Google Pay Component. For that we need to create an intent filter to catch the intent and forward it to the component.